### PR TITLE
 Global name 'theme' is not defined #fixed

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -136,7 +136,7 @@ class CartoonBuilderActivity(SharedActivity):
         return toolbar
 
     def __clear_tape_cb(self, widget):
-        for i in range(theme.TAPE_COUNT):
+        for i in range(TAPE_COUNT):
             self.montage.props.frame = (i, None)
 
     def __tempo_cb(self, widget):


### PR DESCRIPTION
It happened because of the call to 'theme.TAPE_COUNT' which doesn't exist because of the import on line 36 so it's been changed to 'TAPE_COUNT'